### PR TITLE
typechecked islands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .DS_Store
 _site
 _drafts
+@checks.ts

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "url": "https://danthedev.com",
   "scripts": {
     "start": "eleventy --serve --quiet",
-    "build": "tsc && eleventy"
+    "build": "eleventy && tsc"
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.0",

--- a/posts/2023-02-10-interactive-islands.md
+++ b/posts/2023-02-10-interactive-islands.md
@@ -12,7 +12,7 @@ An island is an interactive section within a sea of static content. The term is 
 
 I started pulling this thread about 7 months ago, when I wrote [eleventy-preact-islands](https://github.com/danprince/eleventy-preact-islands). That was after spending a week experimenting with [Astro](https://astro.build/) right after it launched. Then I decided to write a [new static site generator](https://github.com/danprince/melange-experimental). Then I [rewrote it](https://github.com/danprince/sietch). Then I [rewrote the rewrite](https://github.com/danprince/sietch/issues/11). And now I find myself back at [Eleventy](https://www.11ty.dev/) with an implementation for islands in less than 100 lines of code.
 
-{% island confetti "value" "10" %}
+{% island confetti %}
 
 👆 See that unassuming button there? That's an island. If you reload this page with JavaScript disabled you'll see the same button, because it was rendered at build time. You already clicked it didn't you? That was very irresponsible. There's no point trying to create suspense now!
 

--- a/posts/2023-02-10-interactive-islands.md
+++ b/posts/2023-02-10-interactive-islands.md
@@ -12,7 +12,7 @@ An island is an interactive section within a sea of static content. The term is 
 
 I started pulling this thread about 7 months ago, when I wrote [eleventy-preact-islands](https://github.com/danprince/eleventy-preact-islands). That was after spending a week experimenting with [Astro](https://astro.build/) right after it launched. Then I decided to write a [new static site generator](https://github.com/danprince/melange-experimental). Then I [rewrote it](https://github.com/danprince/sietch). Then I [rewrote the rewrite](https://github.com/danprince/sietch/issues/11). And now I find myself back at [Eleventy](https://www.11ty.dev/) with an implementation for islands in less than 100 lines of code.
 
-{% island confetti %}
+{% island confetti "value" "10" %}
 
 👆 See that unassuming button there? That's an island. If you reload this page with JavaScript disabled you'll see the same button, because it was rendered at build time. You already clicked it didn't you? That was very irresponsible. There's no point trying to create suspense now!
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "checkJs": true,
     "module": "node16",
-    "noEmit": true
+    "noEmit": true,
   },
-  "include": ["islands"]
+  "include": ["islands", "@checks.ts"]
 }


### PR DESCRIPTION
There no type safety for the callsites of islands when they're written inside markdown as liquid shortcodes.

This PR translates all of the calls from the current build into actual TypeScript syntax and writes it to a `@check.ts` file that can be verified once the Eleventy build has finished.

Important to change the build ordering so that `tsc` is called _after_ `eleventy` from now on.