### PR TITLE
vanilla islands

### DIFF
--- a/islands/counter.vanilla.js
+++ b/islands/counter.vanilla.js
@@ -1,0 +1,14 @@
+/**
+ * @type {Vanilla<{ value?: number }>}
+ */
+export default {
+  render({ value = 0 }) {
+    return `<button>${value}</button>`;
+  },
+  hydrate({ value = 0 }, element) {
+    const button = element.querySelector("button");
+    if (button) {
+      button.onclick = () => button.textContent = `${value++}`;
+    }
+  }
+}


### PR DESCRIPTION
Not 100% convinced I actually need this yet, but still interesting. Also can't decide on the type signature. For Sietch it made a lot more sense to split `render` and `hydrate` into separate exported functions because it allowed for `render` to be tree-shaken out of the build. Here not so much and might end up with weird logical overlap.

Alternative single function signature:

```ts
type VanillaIsland<P> = (props: P, element?: HTMLElement) => string | void;
```

Then it would be up to the component to check `element` to decide whether to render or to hydrate.
